### PR TITLE
add version schema parameter to System.otp_release [fork to fork]

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -1006,11 +1006,49 @@ defmodule System do
   end
 
   @doc """
-  Returns the Erlang/OTP release number.
+  Returns the Erlang/OTP release in the specified version scheme.
+  If none is specified, defaults to major version only.
   """
-  @spec otp_release :: String.t()
-  def otp_release do
-    :erlang.list_to_binary(:erlang.system_info(:otp_release))
+  @spec otp_release(:major_only | :otp_version_scheme | :semantic_versioning_scheme) :: String.t()
+  def otp_release(version_scheme \\ :major_only) do
+    case version_scheme do
+      :major_only ->
+        :erlang.list_to_binary(:erlang.system_info(:otp_release))
+
+      :otp_version_scheme ->
+        otp_version()
+
+      :semantic_versioning_scheme ->
+        normalize_to_semantic_versioning_scheme(otp_release(:otp_version_scheme))
+    end
+  end
+
+  # From https://github.com/hexpm/hex/blob/92f31922/lib/hex/utils.ex#L202
+  defp otp_version do
+    major = :erlang.system_info(:otp_release) |> List.to_string()
+    vsn_file = Path.join([:code.root_dir(), "releases", major, "OTP_VERSION"])
+
+    try do
+      {:ok, contents} = File.read(vsn_file)
+      String.split(contents, "\n", trim: true)
+    else
+      [full] -> full
+      _ -> major
+    catch
+      :error, _ -> major
+    end
+  end
+
+  # From https://github.com/mirego/elixir-boilerplate/blob/2e5170a2/lib/mix/tasks/erlang.check_version.ex#L42
+  defp normalize_to_semantic_versioning_scheme(version) do
+    version
+    |> String.trim()
+    |> String.split(".")
+    |> case do
+      [major] -> "#{major}.0.0"
+      [major, minor] -> "#{major}.#{minor}.0"
+      [major, minor, patch | _] -> "#{major}.#{minor}.#{patch}"
+    end
   end
 
   @doc """

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -236,7 +236,21 @@ defmodule SystemTest do
     assert System.schedulers_online() >= 1
   end
 
-  test "otp_release/0" do
-    assert is_binary(System.otp_release())
+  test "otp_release/1" do
+    assert System.otp_release() == System.otp_release(:major_only)
+
+    Enum.each(
+      [
+        major_only: 1..1,
+        otp_version_scheme: 2..4,
+        semantic_versioning_scheme: 3..3
+      ],
+      fn {version_scheme, expected_components_range} ->
+        result = System.otp_release(version_scheme)
+        assert is_binary(result)
+        components = String.split(result, ".")
+        assert length(components) in expected_components_range
+      end
+    )
   end
 end


### PR DESCRIPTION
This pull request addresses kind of the same problem addressed by https://github.com/elixir-lang/elixir/pull/8576 without compromising backward compatibility (i.e., no breaking changes).

Having this functionality on System would reduce redundancy (proliferation of copy-and-pasted solutions, including by proeminent Elixir projects such as [`hex_core`](https://github.com/hexpm/hex/blob/92f31922/lib/hex/utils.ex#L202) and [`dialyze`](https://github.com/fishcakez/dialyze/blob/6698ae58/lib/mix/tasks/dialyze.ex#L168)) and avoid maintainability issues in case an alteration has to be propagated (e.g., a bug is found or the specs change).

Furthermore, we have some indication that some people expect such functionality, which is somewhat analogous to `System.version/0`, to be there.